### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::helm::deps()
-#
-#>
-######################################################################
 p6df::modules::helm::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-go
@@ -14,27 +8,6 @@ p6df::modules::helm::deps() {
   )
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::helm::external::brews()
-#
-#>
-######################################################################
-p6df::modules::helm::external::brews() {
-
-  p6df::core::homebrew::cli::brew::install helm
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::helm::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR
-#>
 ######################################################################
 p6df::modules::helm::home::symlinks() {
 
@@ -45,11 +18,13 @@ p6df::modules::helm::home::symlinks() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::helm::langs()
-#
-#>
+p6df::modules::helm::external::brews() {
+
+  p6df::core::homebrew::cli::brew::install helm
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::helm::langs() {
 
@@ -63,6 +38,31 @@ p6df::modules::helm::langs() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::helm::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::helm::external::brews()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::helm::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::helm::langs()
+#
+#>
 ######################################################################
 #<
 #

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::helm::deps()
+#
+#>
+######################################################################
 p6df::modules::helm::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-go
@@ -8,6 +14,13 @@ p6df::modules::helm::deps() {
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::helm::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
 ######################################################################
 p6df::modules::helm::home::symlinks() {
 
@@ -18,6 +31,12 @@ p6df::modules::helm::home::symlinks() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::helm::external::brews()
+#
+#>
+######################################################################
 p6df::modules::helm::external::brews() {
 
   p6df::core::homebrew::cli::brew::install helm
@@ -25,6 +44,12 @@ p6df::modules::helm::external::brews() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::helm::langs()
+#
+#>
 ######################################################################
 p6df::modules::helm::langs() {
 
@@ -38,31 +63,6 @@ p6df::modules::helm::langs() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::helm::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::helm::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::helm::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::helm::langs()
-#
-#>
 ######################################################################
 #<
 #


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None